### PR TITLE
Japanese translation: Prefer newer Solidity constructs

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -30,7 +30,7 @@
   - [Lock pragmas to specific compiler version](#lock-pragmas-to-specific-compiler-version)
   - [Beware division by zero \(Solidity < 0.4\)](#beware-division-by-zero-solidity--04)
   - [Differentiate functions and events](#differentiate-functions-and-events)
-  - [より新しいSolidity構造を好む](#prefer-newer-solidity-constructs)
+  - [より新しいSolidity構文を好む](#prefer-newer-solidity-constructs)
 - [Known Attacks](#known-attacks)
   - [Race Conditions\*](#race-conditions%5C)
   - [Transaction-Ordering Dependence \(TOD\) / Front Running](#transaction-ordering-dependence-tod--front-running)
@@ -511,9 +511,9 @@ function transfer() external {}
 
 <a name="prefer-newer-constructs"></a>
 
-### より新しいSolidity構造を好む
+### より新しいSolidity構文を好む
 
-`selfdestruct`（`suicide` 以上）と `keccak256`（`sha3` 以上）のような構造体/エイリアスを好みます。
+`selfdestruct`（`suicide`より新しい）と `keccak256`（`sha3`より新しい）のような構文/エイリアスを好みます。
 `require（msg.sender.send（1 ether））`のようなパターンは `msg.sender.transfer（1 ether）`のように `transfer（）`を使って単純化することもできます。
 
 <a name="known-attacks"></a>

--- a/README-ja.md
+++ b/README-ja.md
@@ -30,7 +30,7 @@
   - [Lock pragmas to specific compiler version](#lock-pragmas-to-specific-compiler-version)
   - [Beware division by zero \(Solidity < 0.4\)](#beware-division-by-zero-solidity--04)
   - [Differentiate functions and events](#differentiate-functions-and-events)
-  - [Prefer newer Solidity constructs](#prefer-newer-solidity-constructs)
+  - [より新しいSolidity構造を好む](#prefer-newer-solidity-constructs)
 - [Known Attacks](#known-attacks)
   - [Race Conditions\*](#race-conditions%5C)
   - [Transaction-Ordering Dependence \(TOD\) / Front Running](#transaction-ordering-dependence-tod--front-running)
@@ -511,9 +511,10 @@ function transfer() external {}
 
 <a name="prefer-newer-constructs"></a>
 
-### Prefer newer Solidity constructs
+### より新しいSolidity構造を好む
 
-Prefer constructs/aliases such as `selfdestruct` (over `suicide`) and `keccak256` (over `sha3`).  Patterns like `require(msg.sender.send(1 ether))` can also be simplified to using `transfer()`, as in `msg.sender.transfer(1 ether)`.
+`selfdestruct`（`suicide` 以上）と `keccak256`（`sha3` 以上）のような構造体/エイリアスを好みます。
+`require（msg.sender.send（1 ether））`のようなパターンは `msg.sender.transfer（1 ether）`のように `transfer（）`を使って単純化することもできます。
 
 <a name="known-attacks"></a>
 


### PR DESCRIPTION
@sot528 
`Prefer newer Solidity constructs` を日本語訳しました 👷

## 該当箇所
https://github.com/sot528/smart-contract-best-practices/blob/master/README-ja.md#prefer-newer-solidity-constructs